### PR TITLE
Integrate MercadoPago payment and webhook support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.8.9</version>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -109,6 +107,11 @@
 			<groupId>me.paulschwarz</groupId>
 			<artifactId>spring-dotenv</artifactId>
 			<version>2.2.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.mercadopago</groupId>
+			<artifactId>sdk-java</artifactId>
+			<version>2.5.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/pablo/digitalstore/digital_store_api/config/MercadoPagoConfigInitializer.java
+++ b/src/main/java/com/pablo/digitalstore/digital_store_api/config/MercadoPagoConfigInitializer.java
@@ -1,0 +1,18 @@
+package com.pablo.digitalstore.digital_store_api.config;
+
+import com.mercadopago.MercadoPagoConfig;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MercadoPagoConfigInitializer {
+
+    @Value("${mercadopago.access.token}")
+    private String accessToken;
+
+    @PostConstruct
+    public void init() {
+        MercadoPagoConfig.setAccessToken(accessToken);
+    }
+}

--- a/src/main/java/com/pablo/digitalstore/digital_store_api/controller/PaymentWebhookController.java
+++ b/src/main/java/com/pablo/digitalstore/digital_store_api/controller/PaymentWebhookController.java
@@ -1,0 +1,57 @@
+package com.pablo.digitalstore.digital_store_api.controller;
+
+import com.pablo.digitalstore.digital_store_api.service.PaymentWebhookService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/webhooks/mercadopago")
+public class PaymentWebhookController {
+
+    private final PaymentWebhookService paymentWebhookService;
+
+    @Autowired
+    public PaymentWebhookController(PaymentWebhookService paymentWebhookService) {
+        this.paymentWebhookService = paymentWebhookService;
+    }
+
+    @Operation(
+            summary = "Receive MercadoPago webhook notifications",
+            description = "Endpoint to receive and process MercadoPago webhook events such as payment updates."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Notification received and processed successfully",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid payload",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "Internal server error",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    @PostMapping
+    public ResponseEntity<Void> receiveNotification(
+            @Parameter(description = "Payload sent by MercadoPago webhook", required = true)
+            @RequestBody Map<String, Object> payload) {
+        paymentWebhookService.handleWebhookNotification(payload);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/pablo/digitalstore/digital_store_api/model/mapper/MercadoPagoMapper.java
+++ b/src/main/java/com/pablo/digitalstore/digital_store_api/model/mapper/MercadoPagoMapper.java
@@ -1,0 +1,18 @@
+package com.pablo.digitalstore.digital_store_api.model.mapper;
+
+import com.mercadopago.client.preference.PreferenceItemRequest;
+import com.pablo.digitalstore.digital_store_api.model.entity.CartItemEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MercadoPagoMapper {
+
+    public PreferenceItemRequest toPreferenceItem(CartItemEntity item) {
+        return PreferenceItemRequest.builder()
+                .title(item.getProduct().getName())
+                .quantity(item.getQuantity())
+                .currencyId("ARS")
+                .unitPrice(item.getUnitPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/pablo/digitalstore/digital_store_api/service/MercadoPagoService.java
+++ b/src/main/java/com/pablo/digitalstore/digital_store_api/service/MercadoPagoService.java
@@ -1,0 +1,9 @@
+package com.pablo.digitalstore.digital_store_api.service;
+
+import com.mercadopago.exceptions.MPApiException;
+import com.mercadopago.exceptions.MPException;
+import com.mercadopago.resources.preference.Preference;
+
+public interface MercadoPagoService {
+    Preference createPreferenceFromCurrentCart() throws MPException, MPApiException;
+}

--- a/src/main/java/com/pablo/digitalstore/digital_store_api/service/MercadoPagoServiceImpl.java
+++ b/src/main/java/com/pablo/digitalstore/digital_store_api/service/MercadoPagoServiceImpl.java
@@ -1,0 +1,65 @@
+package com.pablo.digitalstore.digital_store_api.service;
+
+
+import com.mercadopago.client.preference.PreferenceBackUrlsRequest;
+import com.mercadopago.client.preference.PreferenceClient;
+import com.mercadopago.client.preference.PreferenceItemRequest;
+import com.mercadopago.client.preference.PreferenceRequest;
+import com.mercadopago.exceptions.MPApiException;
+import com.mercadopago.exceptions.MPException;
+import com.mercadopago.resources.preference.Preference;
+import com.pablo.digitalstore.digital_store_api.model.entity.CartEntity;
+import com.pablo.digitalstore.digital_store_api.model.entity.UserEntity;
+import com.pablo.digitalstore.digital_store_api.model.mapper.MercadoPagoMapper;
+import com.pablo.digitalstore.digital_store_api.repository.CartRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MercadoPagoServiceImpl implements MercadoPagoService {
+
+    private final AuthenticatedUserService authenticatedUserService;
+    private final CartRepository cartRepository;
+    private final MercadoPagoMapper mercadoPagoMapper;
+
+    public MercadoPagoServiceImpl(AuthenticatedUserService authenticatedUserService,
+                                  CartRepository cartRepository,
+                                  MercadoPagoMapper mercadoPagoMapper) {
+        this.authenticatedUserService = authenticatedUserService;
+        this.cartRepository = cartRepository;
+        this.mercadoPagoMapper = mercadoPagoMapper;
+    }
+
+    @Override
+    public Preference createPreferenceFromCurrentCart() throws MPException, MPApiException {
+        UserEntity user = authenticatedUserService.getCurrentUserEntity();
+        CartEntity cart = cartRepository.findByUser(user)
+                .orElseThrow(() -> new IllegalStateException("Cart not found"));
+
+        if (cart.getItems().isEmpty()) {
+            throw new IllegalStateException("Cannot create preference with empty cart");
+        }
+
+        List<PreferenceItemRequest> items = cart.getItems().stream()
+                .map(mercadoPagoMapper::toPreferenceItem)
+                .toList();
+
+        PreferenceBackUrlsRequest backUrlsRequest = PreferenceBackUrlsRequest.builder()
+                .success("https://61e8d70ae705.ngrok-free.app/payment/success")
+                .failure("https://61e8d70ae705.ngrok-free.app/payment/failure")
+                .pending("https://61e8d70ae705.ngrok-free.app/payment/pending")
+                .build();
+
+        PreferenceRequest preferenceRequest = PreferenceRequest.builder()
+                .items(items)
+                .backUrls(backUrlsRequest)
+                .autoReturn("approved")
+                .build();
+
+        PreferenceClient client = new PreferenceClient();
+        return client.create(preferenceRequest);
+    }
+}

--- a/src/main/java/com/pablo/digitalstore/digital_store_api/service/PaymentWebhookService.java
+++ b/src/main/java/com/pablo/digitalstore/digital_store_api/service/PaymentWebhookService.java
@@ -1,0 +1,7 @@
+package com.pablo.digitalstore.digital_store_api.service;
+
+import java.util.Map;
+
+public interface PaymentWebhookService {
+    void handleWebhookNotification(Map<String, Object> payload);
+}

--- a/src/main/java/com/pablo/digitalstore/digital_store_api/service/PaymentWebhookServiceImpl.java
+++ b/src/main/java/com/pablo/digitalstore/digital_store_api/service/PaymentWebhookServiceImpl.java
@@ -1,0 +1,38 @@
+package com.pablo.digitalstore.digital_store_api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import java.util.Map;
+
+@Service
+public class PaymentWebhookServiceImpl implements PaymentWebhookService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PaymentWebhookServiceImpl.class);
+
+    @Override
+    public void handleWebhookNotification(Map<String, Object> payload) {
+        logger.info("📩 MercadoPago webhook received: {}", payload);
+
+        if (!payload.containsKey("type") || !payload.containsKey("data")) {
+            throw new IllegalArgumentException("Invalid MercadoPago webhook payload: missing 'type' or 'data'");
+        }
+
+        String type = (String) payload.get("type");
+        Map<String, Object> data = (Map<String, Object>) payload.get("data");
+
+        if (!"payment".equals(type)) {
+            logger.warn("Ignoring unsupported webhook type: {}", type);
+            return;
+        }
+
+        Long paymentId;
+        try {
+            paymentId = Long.valueOf(data.get("id").toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid payment ID format in webhook payload: " + data.get("id"), e);
+        }
+
+        logger.info("📦 Processing payment notification. Payment ID: {}", paymentId);
+    }
+}


### PR DESCRIPTION
Added MercadoPago Java SDK dependency and implemented configuration, service, mapper, and controller classes to support payment preference creation and webhook notification handling. This enables payment processing and receiving payment status updates via MercadoPago webhooks.